### PR TITLE
Disabled singularity warning in demos when full_rank is specified.

### DIFF
--- a/examples/advanced/demo_fgmres.cpp
+++ b/examples/advanced/demo_fgmres.cpp
@@ -51,6 +51,7 @@ int main(int argc, char *argv[]) {
   // create HIF preconditioner, and factorize with default params
   auto M      = prec_t();
   auto params = hif::DEFAULT_PARAMS;
+  if (full_rank) params.rrqr_cond = hif::Const<double>::MAX;
   // The following parameters are essential to a HIF preconditioner, namely
   // droptol, fill factor, and inverse-norm threshold. Note that the default
   // settings are for robustness. The following parameters are optimized for

--- a/examples/advanced/demo_fgmres_sparsifier.cpp
+++ b/examples/advanced/demo_fgmres_sparsifier.cpp
@@ -60,6 +60,7 @@ int main(int argc, char *argv[]) {
   // create HIF preconditioner, and factorize with default params
   auto M      = prec_t();
   auto params = hif::DEFAULT_PARAMS;
+  if (full_rank) params.rrqr_cond = hif::Const<double>::MAX;
   // The following parameters are essential to a HIF preconditioner, namely
   // droptol, fill factor, and inverse-norm threshold. Note that the default
   // settings are for robustness. The following parameters are optimized for

--- a/examples/advanced/demo_gmreshif.cpp
+++ b/examples/advanced/demo_gmreshif.cpp
@@ -51,6 +51,7 @@ int main(int argc, char *argv[]) {
   // create HIF preconditioner, and factorize with default params
   auto M      = prec_t();
   auto params = hif::DEFAULT_PARAMS;
+  if (full_rank) params.rrqr_cond = hif::Const<double>::MAX;
   // The following parameters are essential to a HIF preconditioner, namely
   // droptol, fill factor, and inverse-norm threshold. Note that the default
   // settings are for robustness. The following parameters are optimized for

--- a/examples/advanced/demo_sparsifier.cpp
+++ b/examples/advanced/demo_sparsifier.cpp
@@ -74,6 +74,7 @@ int main(int argc, char *argv[]) {
   // create HIF preconditioner, and factorize with default params
   auto M      = prec_t();
   auto params = hif::DEFAULT_PARAMS;
+  if (full_rank) params.rrqr_cond = hif::Const<double>::MAX;
   // The following parameters are essential to a HIF preconditioner, namely
   // droptol, fill factor, and inverse-norm threshold. Note that the default
   // settings are for robustness. The following parameters are optimized for


### PR DESCRIPTION
This PR will disable singularity warnings in demos, but ill-conditioning warnings remain since this information is quite important.