### PR TITLE
Updated to work with clang on Mac

### DIFF
--- a/src/hif/builder.hpp
+++ b/src/hif/builder.hpp
@@ -268,10 +268,10 @@ class HIF {
     using cs_type =
         typename std::conditional<CsType::ROW_MAJOR, crs_type, ccs_type>::type;
 
-    static_assert(std::is_same<index_type, typename CsType::index_type>::value,
+    static_assert(sizeof(index_type) == sizeof(typename CsType::index_type),
                   "inconsistent index types");
     static_assert(
-        std::is_same<indptr_type, typename CsType::indptr_type>::value,
+        sizeof(index_type) == sizeof(typename CsType::index_type),
         "inconsistent indptr types");
 
     // print introduction

--- a/src/hif/pre/amd.hpp
+++ b/src/hif/pre/amd.hpp
@@ -97,7 +97,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #  define FLIP(i) (-(i)-2)
 #  define UNFLIP(i) ((i < EMPTY) ? FLIP(i) : (i))
 
-#  define SIZE_T_MAX SIZE_MAX
+#  define AMD_SIZE_T_MAX SIZE_MAX
 
 #endif  // DOXYGEN_SHOULD_SKIP_THIS
 
@@ -1050,8 +1050,8 @@ class AMD {
       if (info) Info[AMD_STATUS] = AMD_INVALID;
       return (AMD_INVALID);
     }
-    if (((size_t)n) >= SIZE_T_MAX / sizeof(Int) ||
-        ((size_t)nz) >= SIZE_T_MAX / sizeof(Int)) {
+    if (((size_t)n) >= AMD_SIZE_T_MAX / sizeof(Int) ||
+        ((size_t)nz) >= AMD_SIZE_T_MAX / sizeof(Int)) {
       if (info) Info[AMD_STATUS] = AMD_OUT_OF_MEMORY;
       return (AMD_OUT_OF_MEMORY);
     }
@@ -1111,7 +1111,7 @@ class AMD {
       slen += n;
     }
     mem += slen;
-    ok = ok && (slen < SIZE_T_MAX / sizeof(Int));
+    ok = ok && (slen < AMD_SIZE_T_MAX / sizeof(Int));
     ok = ok && (slen < Int_MAX);
     if (ok) {
       S = AMD_malloc(slen, sizeof(Int));


### PR DESCRIPTION
On Mac, int64 is translated to `long long` by MATLAB Coder but ptrdiff_t may use `long`. `is_same` fails, but their lengths are the same.

In addition, `SIZE_T_MAX` is apparently used by some clang headers on Mac.